### PR TITLE
Allow use of system pybind11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,10 @@ set(CMAKE_CXX_STANDARD 11)
 # --------------------------------------------------
 
 # initialize pybind for python wrapping
-add_subdirectory(${pybind11_DIR} pybind11)
+find_package(pybind11 CONFIG)
+if(NOT pybind11_FOUND)
+  add_subdirectory(${pybind11_DIR} pybind11)
+endif()
 message(STATUS "ITK_DIR=${ITK_DIR} pybind11_DIR=${pybind11_DIR}")
 
 


### PR DESCRIPTION
In case pybind11 is not available through find_package, fall back to the previous behavior.