### PR TITLE
Updated surfa ref to pull from git hash

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ include_package_data = True
 python_requires >= 3.6
 packages = find:
 install_requires =
-    surfa@git+https://github.com/freesurfer/surfa.git@master
+    surfa@git+https://github.com/freesurfer/surfa.git@c6cddec65f3f3455c60e7954e630ef94368611ec
     scikit-learn
     numpy
     numba


### PR DESCRIPTION
Temporarily changing the surfa ref to a git hash for reproducibility, will reset after the 8.2.0 release