### PR TITLE
Enforce all transforms to be sf.Affine objects before call to SamsegLongitudinal class in the long cli

### DIFF
--- a/samseg/SamsegLongitudinal.py
+++ b/samseg/SamsegLongitudinal.py
@@ -855,12 +855,12 @@ class SamsegLongitudinal:
             # Read in the various time point images, and compute the average
             numberOfTimepoints = len(contrastImageFileNames)
             image0 = sf.load_volume(contrastImageFileNames[0])
-            imageBuffer = image0.transform(sf.Affine(self.tpToBaseTransforms[0]))
+            imageBuffer = image0.transform(self.tpToBaseTransforms[0])
             # Make sure that we are averaging only non zero voxels
             count = np.zeros(imageBuffer.shape)
             count[imageBuffer > 0] += 1
             for timepointNumber in range(1, numberOfTimepoints):
-                tmp = sf.load_volume(contrastImageFileNames[timepointNumber]).transform(sf.Affine(self.tpToBaseTransforms[timepointNumber])).data
+                tmp = sf.load_volume(contrastImageFileNames[timepointNumber]).transform(self.tpToBaseTransforms[timepointNumber]).data
                 imageBuffer += tmp
                 count[tmp > 0] += 1
             # Make sure that we are not dividing by zero for, e.g., background voxels

--- a/samseg/cli/run_samseg_long.py
+++ b/samseg/cli/run_samseg_long.py
@@ -169,7 +169,8 @@ def main():
     else:
         print("Assuming an identity transformation between base and each time point")
         for tp in args.timepoint:
-            tpToBaseTransforms.append(sf.Affine(np.eye(4)))
+            tpVol = sf.load_volume(tp)
+            tpToBaseTransforms.append(sf.Affine(np.eye(4), source=tpVol.geom, target=tpVol.geom))
 
 
     # ------ Run Samsegment ------


### PR DESCRIPTION
Addressing the issue raised in #34.

Cause is that the wrapper call to sf.Affine to ensure all transforms are Affine objects will discard all information about the volume's geometry when no LTA files are passed. This succeeds when the LTA files are passed as they are properly loaded via sf.load_affine, which will contain the correct metadata. Passing the geometry of the input images ensures that there is no mismatch in the grids in the case no LTAs are passed and the default np.eye(4) is used as the affine transform.

This introduces and additional, likely unecessary call to sf.load_volume, which could be handled in a future refactor of the longitudinal code. Alternatively, we could address this by adding functionality to sf.Affine that will extract the geometry information when an Affine object is passed as the matrix.