### PR TITLE
Long affine

### DIFF
--- a/samseg/SamsegLongitudinal.py
+++ b/samseg/SamsegLongitudinal.py
@@ -855,12 +855,12 @@ class SamsegLongitudinal:
             # Read in the various time point images, and compute the average
             numberOfTimepoints = len(contrastImageFileNames)
             image0 = sf.load_volume(contrastImageFileNames[0])
-            imageBuffer = image0.transform(self.tpToBaseTransforms[0])
+            imageBuffer = image0.transform(self.tpToBaseTransforms[0] if isinstance(self.tpToBaseTransforms[0], sf.Affine) else sf.Affine(self.tpToBaseTransforms[0]))
             # Make sure that we are averaging only non zero voxels
             count = np.zeros(imageBuffer.shape)
             count[imageBuffer > 0] += 1
             for timepointNumber in range(1, numberOfTimepoints):
-                tmp = sf.load_volume(contrastImageFileNames[timepointNumber]).transform(self.tpToBaseTransforms[timepointNumber]).data
+                tmp = sf.load_volume(contrastImageFileNames[timepointNumber]).transform(self.tpToBaseTransforms[timepointNumber] if isinstance(self.tpToBaseTransforms[timepointNumber], sf.Affine) else sf.Affine(self.tpToBaseTransforms[timepointNumber])).data
                 imageBuffer += tmp
                 count[tmp > 0] += 1
             # Make sure that we are not dividing by zero for, e.g., background voxels

--- a/samseg/cli/run_samseg_long.py
+++ b/samseg/cli/run_samseg_long.py
@@ -169,8 +169,7 @@ def main():
     else:
         print("Assuming an identity transformation between base and each time point")
         for tp in args.timepoint:
-            tpVol = sf.load_volume(tp)
-            tpToBaseTransforms.append(sf.Affine(np.eye(4), source=tpVol.geom, target=tpVol.geom))
+            tpToBaseTransforms.append(sf.Affine(np.eye(4)))
 
 
     # ------ Run Samsegment ------


### PR DESCRIPTION
Reverted previous fix in #35 in favor of an inline type check for the affine transforms to prevent an extra volume read operation.